### PR TITLE
Rails 5.1 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1
-  - 2.0.0
+  - 2.3.4
+  - 2.2.6
+  - 2.1.10
+  - 2.0.0-p648
 
 addons:
   postgresql: "9.3"
@@ -21,13 +21,18 @@ env:
     - "DATABASE_URL=postgres://postgres@localhost/safer_migrations_test"
   matrix:
     - "ACTIVERECORD_VERSION=4.0.13"
-    - "ACTIVERECORD_VERSION=4.1.10"
-    - "ACTIVERECORD_VERSION=4.2.2"
-    - "ACTIVERECORD_VERSION=5.0.0.rc1"
+    - "ACTIVERECORD_VERSION=4.1.16"
+    - "ACTIVERECORD_VERSION=4.2.8"
+    - "ACTIVERECORD_VERSION=5.0.3"
+    - "ACTIVERECORD_VERSION=5.1.1"
 
 matrix:
   exclude:
-    - rvm: 2.1
-      env: "ACTIVERECORD_VERSION=5.0.0.rc1"
-    - rvm: 2.0.0
-      env: "ACTIVERECORD_VERSION=5.0.0.rc1"
+    - rvm: 2.1.10
+      env: "ACTIVERECORD_VERSION=5.0.3"
+    - rvm: 2.0.0-p648
+      env: "ACTIVERECORD_VERSION=5.0.3"
+    - rvm: 2.1.10
+      env: "ACTIVERECORD_VERSION=5.1.1"
+    - rvm: 2.0.0-p648
+      env: "ACTIVERECORD_VERSION=5.1.1"

--- a/spec/active_record/safer_migrations/migration_spec.rb
+++ b/spec/active_record/safer_migrations/migration_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 RSpec.describe ActiveRecord::SaferMigrations::Migration do
+  let(:migration_base_class) do
+    if ActiveRecord.version >= Gem::Version.new("5.0")
+      ActiveRecord::Migration[ActiveRecord::Migration.current_version]
+    else
+      ActiveRecord::Migration
+    end
+  end
+
   before { nuke_migrations }
   before { TimeoutTestHelpers.set(:lock_timeout, 0) }
   before { TimeoutTestHelpers.set(:statement_timeout, 0) }
@@ -11,7 +19,7 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
 
     shared_examples_for "running the migration" do
       let(:migration) do
-        Class.new(ActiveRecord::Migration) do
+        Class.new(migration_base_class) do
           set_lock_timeout(5000)
           set_statement_timeout(5001)
 
@@ -79,7 +87,7 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
     before { ActiveRecord::SaferMigrations.default_lock_timeout = 6000 }
     before { ActiveRecord::SaferMigrations.default_statement_timeout = 6001 }
     let(:migration) do
-      Class.new(ActiveRecord::Migration) do
+      Class.new(migration_base_class) do
         def change
           $lock_timeout = TimeoutTestHelpers.get(:lock_timeout)
           $statement_timeout = TimeoutTestHelpers.get(:statement_timeout)
@@ -114,7 +122,7 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
     before { ActiveRecord::SaferMigrations.default_lock_timeout = 6000 }
     before { ActiveRecord::SaferMigrations.default_statement_timeout = 6001 }
     let(:base_migration) do
-      Class.new(ActiveRecord::Migration) do
+      Class.new(migration_base_class) do
         set_lock_timeout(7000)
         set_statement_timeout(7001)
         def change


### PR DESCRIPTION
This PR adds support for Rails 5.1 which requires migrations to subclass `ActiveRecord::Migration[<migration version>]`. All changes were updates to tests.