### PR TITLE
Less verbose changing of timeouts

### DIFF
--- a/lib/active_record/safer_migrations/setting_helper.rb
+++ b/lib/active_record/safer_migrations/setting_helper.rb
@@ -32,12 +32,10 @@ module ActiveRecord
       end
 
       def set_new_setting
-        puts "-- set_setting(#{@setting_name.inspect}, #{@value})"
         @connection.set_setting(@setting_name, @value)
       end
 
       def reset_setting
-        puts "-- set_setting(#{@setting_name.inspect}, #{@original_value})"
         @connection.set_setting(@setting_name, @original_value)
       end
 


### PR DESCRIPTION
Changing of timeouts currently adds a lot of noise to migration output (4 of the 8 lines of output below):

```
== 20170524185351 AddErrorToWebhookAttempts: migrating ==========================
-- set_setting(:lock_timeout, 750)
-- set_setting(:statement_timeout, 1500)
-- add_column(:webhook_attempts, :error, :text)
   -> 0.0509s
-- set_setting(:statement_timeout, 0)
-- set_setting(:lock_timeout, 0)
== 20170524185351 AddErrorToWebhookAttempts: migrated (0.0807s) =================
```

This PR removes the lock setting output completely.