### PR TITLE
Handle disabling timeouts in indirect ActiveRecord::Migration subclasses 

### DIFF
--- a/lib/active_record/safer_migrations/migration.rb
+++ b/lib/active_record/safer_migrations/migration.rb
@@ -58,6 +58,19 @@ module ActiveRecord
           say "WARNING: disabling the statement timeout. This is very dangerous."
           self.statement_timeout = 0
         end
+
+        # Delegation of the `say` method didn't work properly with inheritance in Rails 4 so we need
+        # to define the method here. This was fixed in Rails 5 with
+        # https://github.com/rails/rails/commit/f37d92c41036d4eff168b8a8951a8b8a76baa347.
+        if ActiveRecord.version < Gem::Version.new("5.0")
+          def say(message, subitem = false)
+            write "#{subitem ? '   ->' : '--'} #{message}"
+          end
+
+          def write(text = "")
+            puts(text) if verbose
+          end
+        end
       end
     end
   end

--- a/spec/active_record/safer_migrations/migration_spec.rb
+++ b/spec/active_record/safer_migrations/migration_spec.rb
@@ -9,24 +9,29 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
     end
   end
 
+  let(:base_migration) do
+    Class.new(migration_base_class) do
+      def change
+        $lock_timeout = TimeoutTestHelpers.get(:lock_timeout)
+        $statement_timeout = TimeoutTestHelpers.get(:statement_timeout)
+      end
+    end
+  end
+
+  let(:migration) { base_migration }
+
   before { nuke_migrations }
   before { TimeoutTestHelpers.set(:lock_timeout, 0) }
   before { TimeoutTestHelpers.set(:statement_timeout, 0) }
+  before { $lock_timeout = nil }
+  before { $statement_timeout = nil }
 
   describe "setting timeouts explicitly" do
-    before { $lock_timeout = nil }
-    before { $statement_timeout = nil }
-
     shared_examples_for "running the migration" do
       let(:migration) do
-        Class.new(migration_base_class) do
+        Class.new(base_migration) do
           set_lock_timeout(5000)
           set_statement_timeout(5001)
-
-          def change
-            $lock_timeout = TimeoutTestHelpers.get(:lock_timeout)
-            $statement_timeout = TimeoutTestHelpers.get(:statement_timeout)
-          end
         end
       end
 
@@ -82,18 +87,8 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
   end
 
   describe "the default timeouts" do
-    before { $lock_timeout = nil }
-    before { $statement_timeout = nil }
     before { ActiveRecord::SaferMigrations.default_lock_timeout = 6000 }
     before { ActiveRecord::SaferMigrations.default_statement_timeout = 6001 }
-    let(:migration) do
-      Class.new(migration_base_class) do
-        def change
-          $lock_timeout = TimeoutTestHelpers.get(:lock_timeout)
-          $statement_timeout = TimeoutTestHelpers.get(:statement_timeout)
-        end
-      end
-    end
 
     it "sets the lock timeout for the duration of the migration" do
       silence_stream($stdout) { migration.migrate(:up) }
@@ -117,18 +112,12 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
   end
 
   describe "when inheriting from a migration with timeouts defined" do
-    before { $lock_timeout = nil }
-    before { $statement_timeout = nil }
     before { ActiveRecord::SaferMigrations.default_lock_timeout = 6000 }
     before { ActiveRecord::SaferMigrations.default_statement_timeout = 6001 }
     let(:base_migration) do
-      Class.new(migration_base_class) do
+      Class.new(super()) do
         set_lock_timeout(7000)
         set_statement_timeout(7001)
-        def change
-          $lock_timeout = TimeoutTestHelpers.get(:lock_timeout)
-          $statement_timeout = TimeoutTestHelpers.get(:statement_timeout)
-        end
       end
     end
 
@@ -162,6 +151,46 @@ RSpec.describe ActiveRecord::SaferMigrations::Migration do
       it "sets the subclass' statement timeout for the duration of the migration" do
         silence_stream($stdout) { migration.migrate(:up) }
         expect($statement_timeout).to eq(8001)
+      end
+    end
+  end
+
+  describe "disabling timeouts in an indirect subclass of ActiveRecord::Migration" do
+    before do
+      silence_stream($stdout) { migration.migrate(:up) }
+    end
+
+    context "when disabling statement timeouts" do
+      let(:migration) do
+        Class.new(base_migration) do
+          disable_statement_timeout!
+          set_lock_timeout(5000)
+        end
+      end
+
+      it "sets the lock timeout for the duration of the migration" do
+        expect($lock_timeout).to eq(5000)
+      end
+
+      it "sets the statement timeout to 0 for the duration of the migration" do
+        expect($statement_timeout).to eq(0)
+      end
+    end
+
+    context "when disabling lock timeouts" do
+      let(:migration) do
+        Class.new(base_migration) do
+          disable_lock_timeout!
+          set_statement_timeout(5000)
+        end
+      end
+
+      it "sets the lock timeout to 0 for the duration of the migration" do
+        expect($lock_timeout).to eq(0)
+      end
+
+      it "sets the statement timeout for the duration of the migration" do
+        expect($statement_timeout).to eq(5000)
       end
     end
   end


### PR DESCRIPTION
Attempts to disable timeouts in non-direct subclasses of `ActiveRecord::Migration` fail in Rails 4.x with the following exception:

```
     NoMethodError:
       undefined method `say' for nil:NilClass
     # /Users/jturkel/.rvm/gems/ruby-2.3.4@activerecord-safer_migrations/gems/activerecord-4.2.9/lib/active_record/migration.rb:416:in `method_missing'
     # ./lib/active_record/safer_migrations/migration.rb:43:in `disable_lock_timeout!'
```

This was fixed in Rails 5.0 with https://github.com/rails/rails/commit/f37d92c41036d4eff168b8a8951a8b8a76baa347. This PR works around the issue in Rails 4.x by explicitly defining the `ActiveRecord::Migration.say` method which avoids the Rails bug in `ActiveRecord::Migration.method_missing`. The implementation of `say` was copied directly from Rails (with some rubocop fixes applied).
