### PR TITLE
Add development dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "activerecord", "~> #{ENV['ACTIVERECORD_VERSION']}" if ENV["ACTIVERECORD_VERSION"]
-
-group :development do
-  gem "pg", "~> 0.18.3"
-  gem "rspec", "~> 3.3.0"
-  gem "rubocop", "~> 0.35.1"
-end

--- a/activerecord-safer_migrations.gemspec
+++ b/activerecord-safer_migrations.gemspec
@@ -13,4 +13,8 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.add_runtime_dependency "activerecord", ">= 4.0"
+
+  gem.add_development_dependency "pg", "~> 0.18.3"
+  gem.add_development_dependency "rspec", "~> 3.3.0"
+  gem.add_development_dependency "rubocop", "~> 0.35.1"
 end


### PR DESCRIPTION
This is a recommended practice from the Bundler team - the Gemfile doesn't make much sense for gems.