### PR TITLE
Drop support for Rails 4.0 and 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,17 @@ env:
   global:
     - "DATABASE_URL=postgres://postgres@localhost/safer_migrations_test"
   matrix:
-    - "ACTIVERECORD_VERSION=4.0.13"
-    - "ACTIVERECORD_VERSION=4.1.16"
-    - "ACTIVERECORD_VERSION=4.2.8"
-    - "ACTIVERECORD_VERSION=5.0.3"
-    - "ACTIVERECORD_VERSION=5.1.1"
+    - "ACTIVERECORD_VERSION=4.2.9"
+    - "ACTIVERECORD_VERSION=5.0.5"
+    - "ACTIVERECORD_VERSION=5.1.3"
 
 matrix:
   exclude:
     - rvm: 2.1.10
-      env: "ACTIVERECORD_VERSION=5.0.3"
+      env: "ACTIVERECORD_VERSION=5.0.5"
     - rvm: 2.0.0-p648
-      env: "ACTIVERECORD_VERSION=5.0.3"
+      env: "ACTIVERECORD_VERSION=5.0.5"
     - rvm: 2.1.10
-      env: "ACTIVERECORD_VERSION=5.1.1"
+      env: "ACTIVERECORD_VERSION=5.1.3"
     - rvm: 2.0.0-p648
-      env: "ACTIVERECORD_VERSION=5.1.1"
+      env: "ACTIVERECORD_VERSION=5.1.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [#23](https://github.com/gocardless/activerecord-safer_migrations/pull/23) Drop support for Rails 4.0 and 4.1
+
 # 1.0.0 / 2016-05-09
 
 - Support for Rails 5


### PR DESCRIPTION
These versions of Rails are no longer officially supported by the Rails team, so we should stop testing against them.

This also bumps us to the latest patch versions for the remaining versions.