### PR TITLE
Update Postgres Adapter to work with updated Rails 7.2 API

### DIFF
--- a/lib/active_record/safer_migrations/postgresql_adapter.rb
+++ b/lib/active_record/safer_migrations/postgresql_adapter.rb
@@ -33,7 +33,11 @@ module ActiveRecord
       end
 
       def fill_sql_values(sql, values)
-        ActiveRecord::Base.send(:replace_named_bind_variables, sql, values)
+        if Rails.version >= '7.2.0'
+          ActiveRecord::Base.send(:replace_named_bind_variables, self, sql, values)
+        else
+          ActiveRecord::Base.send(:replace_named_bind_variables, sql, values)
+        end
       end
     end
   end


### PR DESCRIPTION
In [fa04810](https://github.com/rails/rails/commit/fa048105d145536538b923fa57465bdeee559e88) Rails changed the method signature for `replace_named_bind_variables` which breaks the postgres adapter. It is unable to get or set settings, including lock and statement timeouts. This PR addresses this, without requiring a version bump.